### PR TITLE
Layout changes

### DIFF
--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -3,7 +3,7 @@ import { untrack } from "svelte";
 import { dndzone } from "svelte-dnd-action";
 import { flip } from "svelte/animate";
 import type { DraggablePlayer } from "../..";
-import { BotInfo, type PsyonixBotInfo } from "../../../bindings/gui";
+import { BotInfo } from "../../../bindings/gui";
 import closeIcon from "../../assets/close.svg";
 import duplicateIcon from "../../assets/duplicate.svg";
 import editIcon from "../../assets/edit.svg";
@@ -163,8 +163,7 @@ async function edit_custom_bot(id: string): Promise<void> {
   .teamBotList {
     padding: 0.6rem;
     overflow: auto;
-    height: 100%;
-    min-height: 4rem;
+    height: 175px;
     display: flex;
     flex-direction: column;
     position: relative;

--- a/frontend/src/pages/Home.svelte
+++ b/frontend/src/pages/Home.svelte
@@ -413,6 +413,7 @@ function handleSearch(event: Event) {
     background-repeat: no-repeat;
     background-position: center;
     background-attachment: fixed;
+    gap: 1rem;
   }
   .page * {
     user-select: none;
@@ -423,13 +424,13 @@ function handleSearch(event: Event) {
     background-color: var(--background);
     padding: 0.6rem;
   }
-  .page > div:not(:first-child) {
-    margin-top: 1rem;
-  }
+
   .availableBots {
     padding-bottom: 0.6rem;
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
+    min-height: fit-content;
   }
   .availableBots header {
     display: flex;
@@ -448,5 +449,6 @@ function handleSearch(event: Event) {
     overflow: auto;
     display: flex;
     flex-direction: column;
+    flex: 0 0 auto;
   }
 </style>


### PR DESCRIPTION
SWZ, I know you have specific preferences for the layout of the GUI, but I don't like how the components currently don't fill up the whole screen when there aren't enough bots in the big bot list and the team bot lists getting massive when there are many bots seems excessive - I think this PR does both solves my problems with the current layout, and hopefully also makes you happy.

The new default layout, which feels a lot more like v4 and fills the whole screen:

![image](https://github.com/user-attachments/assets/59b46a74-14e1-46b2-a646-db9efd729c37)

When there are lots of bots, the GUI still extends off the screen, showing all the bots at once, unlike v4:

![image](https://github.com/user-attachments/assets/0de2bf71-429e-4bec-adbc-deb9084085e0)

But the team bot list drop target is still a decent size since it's a fixed height now:

![image](https://github.com/user-attachments/assets/c0f2c453-c8b0-404d-8812-58f2da5c9afe)
