### PR TITLE
Set `Loadout` to `nil` for Psyonix/Human

### DIFF
--- a/app.go
+++ b/app.go
@@ -199,7 +199,7 @@ func WaitForMatchReady(
 				gamePacket = packet
 			}
 		case <-timer1.C:
-			conn.SendPacket(nil);
+			conn.SendPacket(nil)
 			return fmt.Errorf("Timed out waiting for match start after %s", matchStartDur)
 		}
 	}
@@ -224,7 +224,7 @@ func WaitForMatchReady(
 				// Ignore other packet types in this phase
 			}
 		case <-timer2.C:
-			conn.SendPacket(nil);
+			conn.SendPacket(nil)
 			return fmt.Errorf(
 				"Timed out waiting for match ready after %s",
 				matchReadyDur,
@@ -378,8 +378,8 @@ func (a *App) PickRLBotToml() (string, error) {
 	}
 
 	filename := filepath.Base(path)
-	if  filename == "bot.toml" || filename == "script.toml" ||
-	 	strings.HasSuffix(filename, ".bot.toml") ||
+	if filename == "bot.toml" || filename == "script.toml" ||
+		strings.HasSuffix(filename, ".bot.toml") ||
 		strings.HasSuffix(filename, ".script.toml") {
 		return path, nil
 	}

--- a/players.go
+++ b/players.go
@@ -65,7 +65,7 @@ func (info PsyonixBotInfo) ToPlayerConfig(team uint32) *flat.PlayerConfiguration
 		Team:       team,
 		RootDir:    "",
 		RunCommand: "",
-		Loadout:    &flat.PlayerLoadoutT{},
+		Loadout:    nil,
 		SpawnId:    0,
 		Hivemind:   false,
 	}
@@ -83,7 +83,7 @@ func (info HumanInfo) ToPlayerConfig(team uint32) *flat.PlayerConfigurationT {
 		Team:       team,
 		RootDir:    "",
 		RunCommand: "",
-		Loadout:    &flat.PlayerLoadoutT{},
+		Loadout:    nil,
 		SpawnId:    0,
 		Hivemind:   false,
 	}


### PR DESCRIPTION
Also ran `just format`

This fixes a bug where Psyonix bots where core couldn't set randomly psyonix bot loadouts because the GUI was sending non-null loadouts.

Closes https://github.com/RLBot/core/issues/106