### PR TITLE
Don't let `.bots` scroll

### DIFF
--- a/frontend/src/components/Teams/TeamBotList.svelte
+++ b/frontend/src/components/Teams/TeamBotList.svelte
@@ -187,7 +187,6 @@ async function edit_custom_bot(id: string): Promise<void> {
     flex-direction: column;
     gap: 0.5rem;
     min-height: 100%;
-    overflow-y: auto;
     padding-bottom: 1rem;
   }
   .bot {


### PR DESCRIPTION
By doing this, its container is already setup to scroll instead, resulting in a cleaner experience when trying to remove bots from the list.

Before:
![image](https://github.com/user-attachments/assets/bf47f0b0-c58a-4c55-8187-cd3aa6bf2fcd)

After:
![image](https://github.com/user-attachments/assets/7b96b978-0e0b-4af4-a87f-fa8bc02a7156)

Not perfect, but the scrollbar is now further to the right making it a bit easier.
![image](https://github.com/user-attachments/assets/79bfbe61-da50-474f-8cb6-e42bb61381c5)
