### PR TITLE
Set default value in `NiceSelect` if value is invalid

### DIFF
--- a/frontend/src/components/NiceSelect.svelte
+++ b/frontend/src/components/NiceSelect.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
 let {
   value = $bindable(),
-  options = $bindable(),
-  placeholder = $bindable(),
+  options = {},
+  placeholder = "",
 } = $props();
+
 const options_entries = $derived(Object.entries(options));
+$effect(() => {
+  if (
+    value !== "" &&
+    !options_entries.some(([_, v]) => v === value)
+  ) {
+    value = options_entries[0][1];
+  }
+});
 </script>
 
 <label class="select" for="slct">


### PR DESCRIPTION
This fixes the dropdowns being blank after we update the internal values by defaulting to the first item in the list. Since matches refuse to start when any dropdown is blank, I think this is a good solution.

A default value is not set if the value is empty because for some items (e.x. the game mode preset select) a blank value is perfectly valid.